### PR TITLE
chore: Reran the generation, seems to fix encoding error

### DIFF
--- a/docs/aim.html
+++ b/docs/aim.html
@@ -5,9 +5,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>

--- a/docs/join.html
+++ b/docs/join.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>

--- a/docs/members.html
+++ b/docs/members.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>
@@ -80,9 +80,9 @@
     <p>
         <ul>
             
-                <li>Alexander HultnÃ©r</li>
+                <li>Alexander Hultnér</li>
             
-                <li>JÃ¼rgen Gmach</li>
+                <li>Jürgen Gmach</li>
             
                 <li>Abdur-Rahmaan Janhangeer</li>
             

--- a/docs/takeover.html
+++ b/docs/takeover.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>

--- a/docs/translations.html
+++ b/docs/translations.html
@@ -4,9 +4,9 @@
         
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta charset="utf-8">
-<meta name="description" content="Basic jamstack site">
-<meta name="keywords" content="python, jamstack">
-<meta name="author" content="R Ja">
+<meta name="description" content="Flask Community Workgroup">
+<meta name="keywords" content="python, Flask, community">
+<meta name="author" content="Flask Community">
 <meta name="theme-color" content="#111" />
 <link rel="icon" href="">
 <script type="text/javascript" src="js/script.js"></script>


### PR DESCRIPTION
Encoding in the checked in files is erroneous, can't detect what encoding it actually is but rerunning the detection fixes it.

This also updated a bunch of meta tags which I suspect used default values before but correct values now.

My test of the previous encoding, also tried file, iconv and chardet without any success.
![Screenshot 2021-05-07 at 14 49 37](https://user-images.githubusercontent.com/2669034/117453105-d6b8bc00-af44-11eb-99a6-b27a98b95f08.png)
